### PR TITLE
Remove inaccurate claim that HALOS uses Agent Protocol internally

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ See [docker/README.md](docker/README.md) for build and multi-platform options.
 
 - **[Manifest](spec/manifest.json)** — Machine-readable entry point; agents discover version, core, extensions
 - **[Spec (human-readable)](spec/spec.md)** — Core and optional extensions
-- **[Provenance Model (halos-spec)](https://github.com/northharbor-dev/halos-spec)** — Specifies the types of data and events to be collected to satisfy HALOS provenance intent. Not a mandated implementation; a curated library of reference implementations will be built over time.
+- **[Provenance Model (halos-spec)](https://github.com/northharbor-dev/halos-spec)** — Defines the structure of HALOS provenance records: machine-readable descriptions of how artifacts were created through human–agent collaboration, implementing HALOS-CORE-3 and HALOS-CORE-4. Not a mandated implementation; domain profiles map HALOS principles to specific toolchains.
 - **[Related Specs](spec/RELATED_SPECS.md)** — How HALOS fits in the agent-spec ecosystem and future mapping options
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ See [docker/README.md](docker/README.md) for build and multi-platform options.
 
 - **[Manifest](spec/manifest.json)** — Machine-readable entry point; agents discover version, core, extensions
 - **[Spec (human-readable)](spec/spec.md)** — Core and optional extensions
+- **[Provenance Model (halos-spec)](https://github.com/northharbor-dev/halos-spec)** — Specifies the types of data and events to be collected to satisfy HALOS provenance intent. Not a mandated implementation; a curated library of reference implementations will be built over time.
 - **[Related Specs](spec/RELATED_SPECS.md)** — How HALOS fits in the agent-spec ecosystem and future mapping options
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It is developed in public through this repository and stewarded by NorthHarbor D
 
 This repository is **not** a software implementation. It is a conceptual framework and evolving specification that may inform many future systems, including commercial, open-source, and research efforts.
 
-HALOS internally uses the [Agent Protocol](https://agentprotocol.ai/specification) to govern its own agent behavior, but does not require adopters to do the same. Implementation of the spec is up to the maintainers of each agent ecosystem. See [Related Specs → Implementation Choices](spec/RELATED_SPECS.md#implementation-choices).
+HALOS is a principles framework, not an implementation. How agents execute those principles — via Agent Protocol, OSSA, A2A, or any other runtime — is left to the maintainers of each ecosystem. See [Related Specs](spec/RELATED_SPECS.md).
 
 ## For AI Agents
 

--- a/spec/RELATED_SPECS.md
+++ b/spec/RELATED_SPECS.md
@@ -28,7 +28,7 @@ Other specs address those concerns. HALOS can coexist with, or eventually be imp
 
 | Spec | Scope | HALOS Relationship |
 |------|-------|---------------------|
-| **[halos-spec](https://github.com/northharbor-dev/halos-spec)** | Provenance model: the types of data and events to be collected to satisfy HALOS provenance intent | **Provenance.** Defines the data model that gives HALOS attribution and transparency requirements concrete form. Not a mandated implementation; a curated library of reference implementations will be built over time. |
+| **[halos-spec](https://github.com/northharbor-dev/halos-spec)** | Provenance model: the structure of HALOS provenance records — machine-readable descriptions of how artifacts were created through human–agent collaboration | **Provenance.** Gives HALOS-CORE-3 and HALOS-CORE-4 concrete form. Not a mandated implementation; domain profiles map HALOS principles to specific toolchains. |
 
 ---
 

--- a/spec/RELATED_SPECS.md
+++ b/spec/RELATED_SPECS.md
@@ -40,7 +40,7 @@ Other specs address those concerns. HALOS can coexist with, or eventually be imp
 |------|-------------------|
 | Agent Skills | **Capabilities.** Skills define *what* an agent can do; HALOS defines *how* it should behave when doing it. Skills can be HALOS-aligned if their instructions embody the principles. |
 | OSSA | **Structural.** OSSA defines the agent manifest; HALOS could map as a behavioral overlay or constraint set for OSSA agents claiming alignment. |
-| Agent Protocol | **Execution.** Protocol defines how tasks run; HALOS principles apply regardless of execution model. HALOS internally uses the Agent Protocol to govern its own agent behavior (see [Implementation Choices](#implementation-choices)). |
+| Agent Protocol | **Execution.** Protocol defines how tasks run; HALOS principles apply regardless of execution model. Implementations may choose Agent Protocol as their runtime, but HALOS does not require it. |
 | A2A | **Communication.** A2A defines agent-to-agent messages; HALOS governs the behavioral norms underlying that communication. |
 | ADP | **Discovery.** ADP enables finding agents; HALOS-aligned agents could advertise alignment in their discovery manifests. |
 
@@ -55,9 +55,9 @@ Other specs address those concerns. HALOS can coexist with, or eventually be imp
 
 ## Implementation Choices
 
-HALOS internally uses the [Agent Protocol](https://agentprotocol.ai/specification) to govern its own agent behavior. This choice is transparent and on the record.
+HALOS is a principles framework, not an implementation. It does not use, bundle, or require Agent Protocol or any other runtime.
 
-**HALOS does not mandate this for anyone else.** The specification defines principles and requirements; how to implement them is up to the maintainers of each agent ecosystem. Some may use Agent Protocol; others may use OSSA, A2A, custom tooling, or entirely different stacks. HALOS remains implementation-agnostic — what matters is alignment with the core principles, not the particular runtime or framework used to achieve it.
+How to implement the principles is up to the maintainers of each agent ecosystem. Some may use Agent Protocol; others may use OSSA, A2A, custom tooling, or entirely different stacks. HALOS remains implementation-agnostic — what matters is alignment with the core principles, not the particular runtime or framework used to achieve it.
 
 ---
 

--- a/spec/RELATED_SPECS.md
+++ b/spec/RELATED_SPECS.md
@@ -24,6 +24,14 @@ Other specs address those concerns. HALOS can coexist with, or eventually be imp
 
 ---
 
+## Companion Specs (NorthHarbor)
+
+| Spec | Scope | HALOS Relationship |
+|------|-------|---------------------|
+| **[halos-spec](https://github.com/northharbor-dev/halos-spec)** | Provenance model: the types of data and events to be collected to satisfy HALOS provenance intent | **Provenance.** Defines the data model that gives HALOS attribution and transparency requirements concrete form. Not a mandated implementation; a curated library of reference implementations will be built over time. |
+
+---
+
 ## Related Specs (Full List)
 
 | Spec | Source | Scope | Format | Covers | Used By / Spec |

--- a/spec/manifest.json
+++ b/spec/manifest.json
@@ -2,6 +2,7 @@
   "version": "1.0.0",
   "specUrl": "https://halos.northharbor.dev/spec/manifest.json",
   "relatedSpecs": [
+    { "id": "halos-spec", "source": "NorthHarbor Development", "url": "https://github.com/northharbor-dev/halos-spec", "relationship": "provenance" },
     { "id": "agent-skills", "source": "Anthropic / agentskills.io", "url": "https://agentskills.io/specification", "relationship": "capabilities" },
     { "id": "ossa", "source": "Open Standard for Software Agents", "url": "https://openstandardagents.org/specification/", "relationship": "structural" },
     { "id": "agent-protocol", "source": "agentprotocol.ai", "url": "https://agentprotocol.ai/specification", "relationship": "execution" },


### PR DESCRIPTION
HALOS is a principles framework with no implementation. The earlier draft
language ("HALOS internally uses the Agent Protocol") was carried over
before the specs were split into a separate repo and no longer reflects
reality. Updated README.md and spec/RELATED_SPECS.md to be accurate:
HALOS is implementation-agnostic and does not use or require any runtime.

https://claude.ai/code/session_011HbALKHH45Nx5XhqhXDJgh