### PR TITLE
Update whitepaper v0.2 reference for enhanced draft

### DIFF
--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -241,7 +241,7 @@ The following table illustrates how HALOS relates to complementary systems. The 
 
 ## 9. Future Directions
 
-* **Graph-based provenance** (v0.2+) — richer modeling of multi-contributor, multi-step workflows
+* **Graph-based provenance** (v0.2 draft) — richer modeling of multi-contributor, multi-step workflows with decision provenance, human–AI interaction semantics, and policy evaluation traces
 * **Domain profiles** — implementation guidance mapping HALOS principles to specific industries and toolchains (software development, regulated healthcare, consumer platforms)
 * **Cryptographic signing** of HALOS metadata — tamper-evident provenance records
 * **Identity integration** (OIDC, SPIFFE) — tying provenance to verified identities


### PR DESCRIPTION
## Summary

- Updates the whitepaper's "Future Directions" section to reflect that the v0.2 provenance draft now includes decision provenance, human–AI interaction semantics, and policy evaluation traces

Minor wording update to keep the halos community repo in sync with the enhanced v0.2 draft in halos-spec.

## Related

- northharbor-dev/halos-spec#16 — the corresponding spec PR with the full v0.2 enhancements

## Test plan

- [x] Verify whitepaper wording is accurate relative to the v0.2 draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)